### PR TITLE
fix typo

### DIFF
--- a/notebooks/00_upload_plots.ipynb
+++ b/notebooks/00_upload_plots.ipynb
@@ -454,7 +454,7 @@
     "plots.plot_sampled(\n",
     "    df, \"macd_nobuy_sampled\", \"macd\", \"nobuy\", 26, \"plots/\", \"close\", \"candle\"\n",
     ")\n",
-    "plots.build_h2o_del_dir(\"plots/\", \"data/macd_nobuy_line.parquet.gzip\", True)\n"
+    "plots.build_h2o_del_dir(\"plots/\", \"data/macd_nobuy_candle.parquet.gzip\", True)\n"
    ]
   },
   {

--- a/notebooks/00_upload_plots_minimal_example.ipynb
+++ b/notebooks/00_upload_plots_minimal_example.ipynb
@@ -498,7 +498,7 @@
     "plots.plot_sampled(\n",
     "    df, \"macd_nobuy_sampled\", \"macd\", \"nobuy\", 26, \"plots/\", \"close\", \"candle\"\n",
     ")\n",
-    "plots.build_h2o_del_dir(\"plots/\", \"data/macd_nobuy_line.parquet.gzip\", True)\n"
+    "plots.build_h2o_del_dir(\"plots/\", \"data/macd_nobuy_candle.parquet.gzip\", True)\n"
    ]
   },
   {


### PR DESCRIPTION
Fixes a typo in the file path. The error appeared separately in each notebook.